### PR TITLE
Fix bug in constructor and refactor validation logic

### DIFF
--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -13,7 +13,7 @@ function validateEmail(email) {
 
 export class InputComponent extends React.Component{
   constructor(props){
-    super();
+    super(props);
 
     this.validate = this.validate.bind(this);
 

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -24,7 +24,7 @@ export class InputComponent extends React.Component{
       inputHeight: Math.max(props.height || 44)
     }
 
-    this.valid = validate(props.value);
+    this.valid = this.validate(props.value);
 
   }
   validate(value){

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -36,7 +36,7 @@ export class InputComponent extends React.Component{
     if(this.props.keyboardType){
       switch (this.props.keyboardType) {
         case 'email-address':
-          this.valid = validateEmail(value);
+          valid = validateEmail(value);
           break;
       }
     }


### PR DESCRIPTION
Fixed a bug in the constructor of the InputComponent.
```this.valid = props.validationFunction(value, this);```
was returning an error of `value is undefined`

In the process, I combined the two blocks of validation code since they were nearly the same.