### PR TITLE
Allow form validation

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -12,24 +12,31 @@ let { View, TextInput,
 export class Form extends React.Component{
   constructor(props){
     super();
+
+    this.componentDidMount = this.componentDidMount.bind(this);
+    this.validateForm = this.validateForm.bind(this);
+
+    this.valid;
     this.values = {};
     React.Children.map(props.children, (child)=> {
       if (!child) {
         return;
       }
-        if(child.ref){
-          this.values[child.ref] = child.props.value;
-        }
-
+      if(child.ref){
+        this.values[child.ref] = child.props.value;
+      }
     });
   }
-
+  componentDidMount(){
+    this.valid = this.validateForm();
+  }
   handleFieldFocused(event, inputHandle){
       this.props.onFocus && this.props.onFocus(event, inputHandle);
   }
   handleFieldChange(field_ref, value){
-     this.values[field_ref] = value;
+    this.values[field_ref] = value;
     this.props.onChange && this.props.onChange(this.values);
+    this.valid = this.validateForm();
   }
   getValues(){
     return this.values;
@@ -43,7 +50,19 @@ export class Form extends React.Component{
 
     return res.join(' ');
   }
+  validateForm(){
+    let result = true;
 
+    Object.values(this.refs).map((child)=> {
+      if (child.valid === false ||
+        (typeof child.valid === 'undefined' && result)
+      ) {
+        result = child.valid;
+      }
+    });
+
+    return result;
+  }
   render(){
     let wrappedChildren = [];
 
@@ -56,19 +75,18 @@ export class Form extends React.Component{
         wrappedChildren.push(React.cloneElement(child, {
           key: child.ref || child.type+i,
           fieldRef : child.ref,
+          ref: child.ref,
           onFocus:this.handleFieldFocused.bind(this),
           onChange:this.handleFieldChange.bind(this)
         }
       ));
       //}
-    }, this)
+    }, this);
 
     return (
       <View style={this.props.style}>
           {wrappedChildren}
       </View>
-
-
-      );
+    );
   }
 }

--- a/src/Form.js
+++ b/src/Form.js
@@ -35,8 +35,8 @@ export class Form extends React.Component{
   }
   handleFieldChange(field_ref, value){
     this.values[field_ref] = value;
-    this.props.onChange && this.props.onChange(this.values);
     this.valid = this.validateForm();
+    this.props.onChange && this.props.onChange(this.values);
   }
   getValues(){
     return this.values;

--- a/src/Form.js
+++ b/src/Form.js
@@ -14,7 +14,8 @@ export class Form extends React.Component{
     super();
 
     this.componentDidMount = this.componentDidMount.bind(this);
-    this.validateForm = this.validateForm.bind(this);
+    this.triggerValidation = this.triggerValidation.bind(this);
+    this.validate = this.validate.bind(this);
 
     this.valid;
     this.values = {};
@@ -28,18 +29,27 @@ export class Form extends React.Component{
     });
   }
   componentDidMount(){
-    this.valid = this.validateForm();
+    this.valid = this.validate();
   }
   handleFieldFocused(event, inputHandle){
-      this.props.onFocus && this.props.onFocus(event, inputHandle);
+    this.props.onFocus && this.props.onFocus(event, inputHandle);
   }
   handleFieldChange(field_ref, value){
     this.values[field_ref] = value;
-    this.valid = this.validateForm();
+    this.valid = this.validate();
     this.props.onChange && this.props.onChange(this.values);
   }
   getValues(){
     return this.values;
+  }
+  triggerValidation() {
+    Object.values(this.refs).map((child)=> {
+      if(child.triggerValidation) {
+        child.triggerValidation();
+      }
+    });
+
+    this.valid = this.validate();
   }
   underscoreToSpaced(str){
     var words = str.split('_');
@@ -50,7 +60,7 @@ export class Form extends React.Component{
 
     return res.join(' ');
   }
-  validateForm(){
+  validate(){
     let result = true;
 
     Object.values(this.refs).map((child)=> {

--- a/src/fields/InputField.android.js
+++ b/src/fields/InputField.android.js
@@ -10,6 +10,7 @@ export class InputField extends React.Component{
   constructor(props){
     super(props);
 
+    this.triggerValidation = this.triggerValidation.bind(this);
     this.validate = this.validate.bind(this);
 
     this.state = {
@@ -18,18 +19,27 @@ export class InputField extends React.Component{
 
     this.valid = this.validate(props.value)
   }
-  validate(value){
-    const {fieldRef, validationFunction} = this.props;
-    let result;
+  triggerValidation() {
+    const {fieldRef} = this.props;
 
     if(this.refs[fieldRef]) {
-      result = this.refs[fieldRef].valid;
-    } else
-    if(validationFunction) {
-      result = validationFunction(value);
+      this.refs[fieldRef].triggerValidation();
     }
 
-    return result;
+    this.valid = this.validate(this.state.value);
+  }
+  validate(value){
+    const {fieldRef, validationFunction} = this.props;
+    let valid;
+
+    if(this.refs[fieldRef]) {
+      valid = this.refs[fieldRef].valid;
+    } else
+    if(validationFunction) {
+      valid = validationFunction(value);
+    }
+
+    return valid;
   }
   handleChange(ref, value) {
     this.setState({value});

--- a/src/fields/InputField.android.js
+++ b/src/fields/InputField.android.js
@@ -4,11 +4,50 @@ import React from 'react';
 import ReactNative from 'react-native';
 import {InputComponent} from '../lib/InputComponent';
 
-let { StyleSheet} = ReactNative;
+const {StyleSheet} = ReactNative;
+
 export class InputField extends React.Component{
+  constructor(props){
+    super(props);
+
+    this.validate = this.validate.bind(this);
+
+    this.state = {
+      value: props.value,
+    }
+
+    this.valid = this.validate(props.value)
+  }
+  validate(value){
+    const {fieldRef, validationFunction} = this.props;
+    let result;
+
+    if(this.refs[fieldRef]) {
+      result = this.refs[fieldRef].valid;
+    } else
+    if(validationFunction) {
+      result = validationFunction(value);
+    }
+
+    return result;
+  }
+  handleChange(ref, value) {
+    this.setState({value});
+
+    this.valid = this.validate(value);
+
+    // pass the value change up the chain
+    if(this.props.onChange) {
+      this.props.onChange(ref, value);
+    }
+  }
+
   render(){
     return(<InputComponent
       {...this.props}
-      />);
+      onChange={this.handleChange.bind(this)}
+      ref={this.props.fieldRef}
+      />
+    );
   }
 }

--- a/src/fields/InputField.ios.js
+++ b/src/fields/InputField.ios.js
@@ -10,6 +10,7 @@ export class InputField extends React.Component{
   constructor(props){
     super(props);
 
+    this.triggerValidation = this.triggerValidation.bind(this);
     this.validate = this.validate.bind(this);
 
     this.state = {
@@ -18,18 +19,27 @@ export class InputField extends React.Component{
 
     this.valid = this.validate(props.value)
   }
-  validate(value){
-    const {fieldRef, validationFunction} = this.props;
-    let result;
+  triggerValidation() {
+    const {fieldRef} = this.props;
 
     if(this.refs[fieldRef]) {
-      result = this.refs[fieldRef].valid;
-    } else
-    if(validationFunction) {
-      result = validationFunction(value);
+      this.refs[fieldRef].triggerValidation();
     }
 
-    return result;
+    this.valid = this.validate(this.state.value);
+  }
+  validate(value){
+    const {fieldRef, validationFunction} = this.props;
+    let valid;
+
+    if(this.refs[fieldRef]) {
+      valid = this.refs[fieldRef].valid;
+    } else
+    if(validationFunction) {
+      valid = validationFunction(value);
+    }
+
+    return valid;
   }
   handleChange(ref, value) {
     this.setState({value});

--- a/src/fields/InputField.ios.js
+++ b/src/fields/InputField.ios.js
@@ -4,11 +4,49 @@ import React from 'react';
 import ReactNative from 'react-native';
 import {InputComponent} from '../lib/InputComponent';
 
-let { StyleSheet} = ReactNative;
+const {StyleSheet} = ReactNative;
+
 export class InputField extends React.Component{
+  constructor(props){
+    super(props);
+
+    this.validate = this.validate.bind(this);
+
+    this.state = {
+      value: props.value,
+    }
+
+    this.valid = this.validate(props.value)
+  }
+  validate(value){
+    const {fieldRef, validationFunction} = this.props;
+    let result;
+
+    if(this.refs[fieldRef]) {
+      result = this.refs[fieldRef].valid;
+    } else
+    if(validationFunction) {
+      result = validationFunction(value);
+    }
+
+    return result;
+  }
+  handleChange(ref, value) {
+    this.setState({value});
+
+    this.valid = this.validate(value);
+
+    // pass the value change up the chain
+    if(this.props.onChange) {
+      this.props.onChange(ref, value);
+    }
+  }
+
   render(){
     return(<InputComponent
       {...this.props}
+      onChange={this.handleChange.bind(this)}
+      ref={this.props.fieldRef}
       labelStyle={formStyles.fieldText}
       inputStyle={[formStyles.input,
           (this.props.multiline)?formStyles.multiline:{},
@@ -20,8 +58,8 @@ export class InputField extends React.Component{
             this.props.containerStyle,
           ]}
       />
-  )
-}
+    )
+  }
 
 }
 

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -13,7 +13,7 @@ function validateEmail(email) {
 
 export class InputComponent extends React.Component{
   constructor(props){
-    super();
+    super(props);
 
     this.validate = this.validate.bind(this);
 

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -24,7 +24,7 @@ export class InputComponent extends React.Component{
       inputHeight: Math.max(props.height || 44)
     }
 
-    this.valid = validate(props.value);
+    this.valid = this.validate(props.value);
 
   }
   validate(value){

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -4,25 +4,25 @@ import React from 'react';
 import ReactNative from 'react-native';
 import {Field} from './Field.js';
 
-let { View, StyleSheet, TextInput, Text} = ReactNative;
+const {View, StyleSheet, TextInput, Text} = ReactNative;
 
 function validateEmail(email) {
-    var re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    return re.test(email);
+  var re = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  return re.test(email);
 }
 
 export class InputComponent extends React.Component{
   constructor(props){
     super(props);
 
-    this.validate = this.validate.bind(this);
+    this.validate = this.validate.bind(this)
 
     this.state = {
       labelWidth: 0,
       value: props.value,
       minFieldHeight: props.height || 44,
       inputHeight: Math.max(props.height || 44)
-    }
+    };
 
     this.valid = this.validate(props.value);
 
@@ -134,9 +134,9 @@ export class InputComponent extends React.Component{
               : null
             }
         </View>
-    </Field>
-  )
-}
+      </Field>
+    )
+  }
 
 }
 

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -15,6 +15,7 @@ export class InputComponent extends React.Component{
   constructor(props){
     super(props);
 
+    this.triggerValidation = this.triggerValidation.bind(this);
     this.validate = this.validate.bind(this)
 
     this.state = {
@@ -27,16 +28,18 @@ export class InputComponent extends React.Component{
     this.valid = this.validate(props.value);
 
   }
+  triggerValidation() {
+    this.valid = this.validate(this.state.value);
+  }
   validate(value){
     let valid;
-
     if(this.props.validationFunction) {
       valid = this.props.validationFunction(value, this);
     } else
     if(this.props.keyboardType){
       switch (this.props.keyboardType) {
         case 'email-address':
-          this.valid = validateEmail(value);
+          valid = validateEmail(value);
           break;
       }
     }
@@ -58,11 +61,11 @@ export class InputComponent extends React.Component{
   }
   handleChange(event){
 
-    var value = event.nativeEvent.text;
+    const value = event.nativeEvent.text;
 
     this.valid = this.validate(value);
 
-    this.setState({value:value,
+    this.setState({value,
       inputHeight: Math.max(this.state.minFieldHeight,
         (event.nativeEvent.contentSize && this.props.multiline)?event.nativeEvent.contentSize.height:0)
       });


### PR DESCRIPTION
This is a pull request to allow forms and inputs to state if they are valid or not (InputComponents already had this ability but the InputFields were not passing the info through).

To accomplish this, I made sure the refs were getting set and passed through correctly (so that we can access the child components).  Then I created a `valid` property on the form and InputField.  Each time the change handler is triggered, a parent component checks it child or children to see if they are valid or not and sets its own `valid` property.  The value change is then propagated up to the parent.

The form has to collapse the valid properties of all of its children into one value.  When reviewing the `valid` property of each child, I assumed that `true` and `false` are pretty self evident, but that `undefined` means the child doesn't know.  Therefore, any child with a `false` sets the form's `valid` property to `false`.  If there are no falses, any child with an `undefined` sets the form's `valid` property to `undefined`.  The form's `valid` property is only set to `true`, if and only if, all children have a `valid` property of `true`.

Collapsing the form children in this way allows the form handler to decide what to do in each situation.