### PR TITLE
Allowing more styles of datePicker to be set through props.

### DIFF
--- a/src/fields/DatePickerField.ios.js
+++ b/src/fields/DatePickerField.ios.js
@@ -15,8 +15,8 @@ export class DatePickerField extends React.Component{
     return(<DatePickerComponent
       {...this.props}
       ref='datePickerComponent'
-      labelStyle={formStyles.fieldText}
-      valueStyle = {formStyles.fieldValue}
+      labelStyle={[formStyles.fieldText, this.props.labelStyle]}
+      valueStyle = {[formStyles.fieldValue,this.props.valueStyle]}
 
       valueContainerStyle = {[formStyles.alignRight,
           formStyles.horizontalContainer,this.props.valueContainerStyle]}


### PR DESCRIPTION
I noticed that there isn’t any way currently to set the valueStyle and labelStyle for a DatePicker for iOS. Looking at how you did this for other fields, I suggest these changes.