### PR TITLE
Add styling without causing warnings

### DIFF
--- a/src/fields/PickerField.android.js
+++ b/src/fields/PickerField.android.js
@@ -20,6 +20,7 @@ export class PickerField extends React.Component{
           [
             formStyles.fieldContainer,
             this.props.containerStyle,
+            this.props.pickerStyle,
           ],
 
 

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -98,17 +98,17 @@ export class InputComponent extends React.Component{
     return this.valid;
   }
   handleLayoutChange(e){
-    let {x, y, width, height} = {... e.nativeEvent.layout};
+    // let {x, y, width, height} = {... e.nativeEvent.layout};
 
-    this.setState(e.nativeEvent.layout);
-    //e.nativeEvent.layout: {x, y, width, height}}}.
+    // this.setState(e.nativeEvent.layout);
+    // //e.nativeEvent.layout: {x, y, width, height}}}.
   }
 
   handleLabelLayoutChange(e){
-    let {x, y, width, height} = {... e.nativeEvent.layout};
+    // let {x, y, width, height} = {... e.nativeEvent.layout};
 
-    this.setState({labelWidth:width});
-    //e.nativeEvent.layout: {x, y, width, height}}}.
+    // this.setState({labelWidth:width});
+    // //e.nativeEvent.layout: {x, y, width, height}}}.
   }
   handleChange(event){
     const value = event.nativeEvent.text;

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -98,16 +98,20 @@ export class InputComponent extends React.Component{
     return this.valid;
   }
   handleLayoutChange(e){
-    // let {x, y, width, height} = {... e.nativeEvent.layout};
+	  if (Platform.OS === 'ios') {
+		  let {x, y, width, height} = {... e.nativeEvent.layout};
 
-    // this.setState(e.nativeEvent.layout);
+	      this.setState(e.nativeEvent.layout);
+	  }
     // //e.nativeEvent.layout: {x, y, width, height}}}.
   }
 
   handleLabelLayoutChange(e){
-    // let {x, y, width, height} = {... e.nativeEvent.layout};
+	  if (Platform.OS === 'ios') {
+		  let {x, y, width, height} = {... e.nativeEvent.layout};
 
-    // this.setState({labelWidth:width});
+	      this.setState({labelWidth:width});
+	  }
     // //e.nativeEvent.layout: {x, y, width, height}}}.
   }
   handleChange(event){

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React from 'react';
-import ReactNative from 'react-native';
+import ReactNative, { Platform } from 'react-native';
 import {Field} from './Field.js';
 
 const {View, StyleSheet, TextInput, Text} = ReactNative;

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -34,6 +34,7 @@ export class PickerComponent extends React.Component{
 
       if(this.props.onChange)      this.props.onChange(value);
       if(this.props.onValueChange) this.props.onValueChange(value);
+      if(this.props.autoclose)     this._togglePicker();
     }
 
     _scrollToInput (event) {


### PR DESCRIPTION
You could customize the color of the picker via the containerStyles property, but it causes warnings since you can't pass color to View elements.
This new property enables to customize the Picker color, without generating warnings
