### PR TITLE
Styles helpTextContainer and helpText

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.9.10"
+  "version": "0.9.11"
 }

--- a/src/lib/Field.js
+++ b/src/lib/Field.js
@@ -9,7 +9,7 @@ export class Field extends React.Component{
     let fieldHelpText =
       this.props.helpTextComponent
       || ((this.props.helpText)
-          ? <HelpText text={this.props.helpText} />
+          ? <HelpText {...this.props} text={this.props.helpText} />
           : null);
 
     if(this.props.onPress){

--- a/src/lib/HelpText.js
+++ b/src/lib/HelpText.js
@@ -10,8 +10,8 @@ export class HelpText extends React.Component{
   render(){
     if(!this.props.text) return null;
     return (
-      <View style={formStyles.helpTextContainer}>
-        <Text style={formStyles.helpText}>{this.props.text}</Text>
+      <View style={this.props.helpTextStyles.helpTextContainer}>
+        <Text style={this.props.helpTextStyles.helpText}>{this.props.text}</Text>
     </View>);
   }
 }

--- a/src/lib/HelpText.js
+++ b/src/lib/HelpText.js
@@ -10,8 +10,8 @@ export class HelpText extends React.Component{
   render(){
     if(!this.props.text) return null;
     return (
-      <View style={this.props.helpTextStyles.helpTextContainer}>
-        <Text style={this.props.helpTextStyles.helpText}>{this.props.text}</Text>
+      <View style={this.props.helpTextStyles && this.props.helpTextStyles.helpTextContainer ? this.props.helpTextStyles.helpTextContainer : formStyles.helpTextContainer}>
+        <Text style={this.props.helpTextStyles && this.props.helpTextStyles.helpText ? this.props.helpTextStyles.helpText : formStyles.helpTextContainer}>{this.props.text}</Text>
     </View>);
   }
 }


### PR DESCRIPTION
Allow helpTextContainer and helpText to be styled via props from a field


  <InputField
              ref='addressee'
              placeholder='Name'
              validationFunction = {isRequired}
              helpText = {(displayFieldError)('addressee', this.refs.accountDetailsForm, this.state.formData)}
              style={styles.inputText}
              **helpTextStyles={helpTextStyles}**/>


export default StyleSheet.create({
  helpTextContainer:{
     marginTop:9,
     marginBottom: 25,
     paddingLeft: 20,
     paddingRight: 20,
   },
   helpText:{
     color: 'red'
   }
})


