### PR TITLE
Add missing style prop

### DIFF
--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -95,7 +95,7 @@ export class DatePickerComponent extends React.Component{
             : null
           }
           {placeholderComponent}
-          <View style={[formStyles.alignRight, formStyles.horizontalContainer]}>
+          <View style={[formStyles.alignRight, formStyles.horizontalContainer, this.props.valueContainerStyle]}>
             <Text style={[formStyles.fieldValue,this.props.valueStyle ]}>{ valueString }</Text>
 
             {(iconRight)


### PR DESCRIPTION
Yesterday I abandoned my old forked copy of this repo and updated my entire app to use the latest version. Really appreciate all the work you've put into this. I'll be using/contributing to this repo going forward—starting with this tiny PR. While doing updates, I noticed that the valueContainerStyle prop was never set on the DatePickerComponent.