### PR TITLE
Removes toUpperCase call on Separator label

### DIFF
--- a/src/fields/Separator.js
+++ b/src/fields/Separator.js
@@ -8,7 +8,7 @@ export class Separator extends React.Component{
      return(<View style={[formStyles.separatorContainer, this.props.containerStyle]}>
        {
          (this.props.label)?
-         <Text style={[formStyles.separator,this.props.labelStyle]}>{this.props.label.toUpperCase()}</Text>
+         <Text style={[formStyles.separator,this.props.labelStyle]}>{this.props.label}</Text>
        : null
      }
        </View>


### PR DESCRIPTION
This pull request removes the toUpperCase() call on the separator label. Not everyone might want an all uppercase label. This allows the freedom to choose depending on your label prop.

Otherwise, to my knowledge, there is no way around the uppercase with the current code. Please correct me if I'm wrong. 

Open to all thoughts and suggestions. Thank you.