### PR TITLE
Newer versions of React switched to prop-types package.

### DIFF
--- a/src/fields/InputField.ios.js
+++ b/src/fields/InputField.ios.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactNative from 'react-native';
 import {InputComponent} from '../lib/InputComponent';
 
@@ -41,8 +42,8 @@ export class InputField extends React.Component{
 }
 
 InputField.propTypes = {
-  multiline: React.PropTypes.bool,
-  placeholder:React.PropTypes.string,
+  multiline: PropTypes.bool,
+  placeholder:PropTypes.string,
 }
 
 

--- a/src/lib/DatePickerComponent.android.js
+++ b/src/lib/DatePickerComponent.android.js
@@ -2,6 +2,7 @@
 
 
 import React from 'react';
+import PropTypes from 'prop-types';
 let { View, StyleSheet, TextInput, Text, DatePickerAndroid} = require('react-native');
 import {Field} from './Field';
 
@@ -107,7 +108,7 @@ import {Field} from './Field';
   }
 
   DatePickerComponent.propTypes = {
-    dateTimeFormat: React.PropTypes.func
+    dateTimeFormat: PropTypes.func
   }
 
   DatePickerComponent.defaultProps = {

--- a/src/lib/DatePickerComponent.ios.js
+++ b/src/lib/DatePickerComponent.ios.js
@@ -2,6 +2,7 @@
 
 
 import React from 'react';
+import PropTypes from 'prop-types';
 let { View, StyleSheet, TextInput, Text, DatePickerIOS} = require('react-native');
 import {Field} from './Field';
 
@@ -117,9 +118,9 @@ export class DatePickerComponent extends React.Component{
 }
 
 DatePickerComponent.propTypes = {
-  dateTimeFormat: React.PropTypes.func,
-  pickerWrapper: React.PropTypes.element,
-  prettyPrint: React.PropTypes.bool
+  dateTimeFormat: PropTypes.func,
+  pickerWrapper: PropTypes.element,
+  prettyPrint: PropTypes.bool
 }
 
 DatePickerComponent.defaultProps = {

--- a/src/lib/Field.js
+++ b/src/lib/Field.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {HelpText} from './HelpText';
 let { View, StyleSheet, Text, TouchableHighlight} = require('react-native');
 
@@ -29,8 +30,8 @@ export class Field extends React.Component{
   }
 }
 Field.propTypes = {
-  helpTextComponent: React.PropTypes.element,
-  helpText: React.PropTypes.string
+  helpTextComponent: PropTypes.element,
+  helpText: PropTypes.string
 }
 
 

--- a/src/lib/HelpText.js
+++ b/src/lib/HelpText.js
@@ -3,6 +3,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { View, StyleSheet, Text} from 'react-native';
 
@@ -17,7 +18,7 @@ export class HelpText extends React.Component{
 }
 
 HelpText.propTypes = {
-  text: React.PropTypes.string
+  text: PropTypes.string
 }
 
 

--- a/src/lib/InputComponent.js
+++ b/src/lib/InputComponent.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactNative, { Platform } from 'react-native';
 import {Field} from './Field.js';
 
@@ -200,8 +201,8 @@ export class InputComponent extends React.Component{
 }
 
 // InputComponent.propTypes = {
-//   multiline: React.PropTypes.bool,
-//   placeholder:React.PropTypes.string,
+//   multiline: PropTypes.bool,
+//   placeholder:PropTypes.string,
 // }
 
 InputComponent.propTypes = {

--- a/src/lib/PickerComponent.ios.js
+++ b/src/lib/PickerComponent.ios.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactNative from 'react-native';
 let { View, StyleSheet, TextInput, Text, Picker} = ReactNative;
 import {Field} from '../lib/Field';
@@ -154,7 +155,7 @@ export class PickerComponent extends React.Component{
   }
 
   PickerComponent.propTypes = {
-    pickerWrapper: React.PropTypes.element,
+    pickerWrapper: PropTypes.element,
   }
 
   PickerComponent.defaultProps = {

--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -2,6 +2,7 @@
 
 
 import React from 'react';
+import PropTypes from 'prop-types';
 let { View, StyleSheet, TextInput, Text, TimePickerAndroid} = require('react-native');
 import {Field} from './Field';
 
@@ -97,8 +98,8 @@ import {Field} from './Field';
 
   }
   TimePickerComponent.propTypes = {
-    dateTimeFormat: React.PropTypes.func,
-    prettyPrint: React.PropTypes.bool
+    dateTimeFormat: PropTypes.func,
+    prettyPrint: PropTypes.bool
   }
 
   TimePickerComponent.defaultProps = {


### PR DESCRIPTION
Was trying to use this with the newer versions of React-Native and kept getting undefined errors. React recently switched to a different package called prop-types. I did the small fixes and it now works in my project.

sauce: https://reactjs.org/docs/typechecking-with-proptypes.html