### PR TITLE
Use datetimeTimeFormat to show time value

### DIFF
--- a/src/lib/TimePickerComponent.android.js
+++ b/src/lib/TimePickerComponent.android.js
@@ -53,7 +53,6 @@ import {Field} from './Field';
 
     }
     render(){
-      let timeValue =this.props.dateTimeFormat(this.state.date);
       let placeholderComponent = (this.props.placeholderComponent)
                         ? this.props.placeholderComponent
                         : <Text style={[formStyles.fieldText, this.props.placeholderStyle]}>{this.props.placeholder}</Text>
@@ -69,7 +68,7 @@ import {Field} from './Field';
           {placeholderComponent}
           <View style={[formStyles.alignRight, formStyles.horizontalContainer]}>
             <Text style={[formStyles.fieldValue,this.props.valueStyle ]}>{
-            (this.state.date)?this.state.date.toLocaleDateString():""
+            this.props.dateTimeFormat(this.state.date)
           }</Text>
 
 


### PR DESCRIPTION
Android `TimePickerComponent` was not honouring `dateTimeFormat` function from props.
If `dateTimeFormat` is not passed from parent component, it uses the default value.